### PR TITLE
make Parser::Parse accept istreams instead of stringstream

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -7,4 +7,4 @@ a license to everyone to use it as detailed in LICENSE.)
 M. Petra Baranski (info@progsource.de)
 Patrick José Pereira (patrickelectric@gmail.com)
 Martin Kopecky (martin.kopecky357@gmail.com)
-
+Evan Klitzke (evan@eklitzke.org)

--- a/include/maddy/parser.h
+++ b/include/maddy/parser.h
@@ -73,11 +73,11 @@ public:
    * Parse
    *
    * @method
-   * @param {const std::stringstream&} markdown
+   * @param {const std::istream&} markdown
    * @return {std::string} HTML
    */
   std::string
-  Parse(std::stringstream& markdown) const
+  Parse(std::istream& markdown) const
   {
     std::string result = "";
     std::shared_ptr<BlockParser> currentBlockParser = nullptr;


### PR DESCRIPTION
This allows you to pass e.g. a `std::ifstream` directly to `Parser::Parse()`. The existing tests all pass with this change.