### PR TITLE
Headline inline parsing

### DIFF
--- a/.github/ISSUE_TEMPLATE/other.yml
+++ b/.github/ISSUE_TEMPLATE/other.yml
@@ -1,0 +1,11 @@
+name: Other
+description: Anything that doesn't fit into one of the other issue categories
+title: ""
+body:
+  - type: textarea
+    id: whats-up
+    attributes:
+      label: What is the issue?
+      description: Is some tooling not working? Performance issues? ...
+    validations:
+      required: true

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - master
+      - dev
   pull_request:
     branches:
       - master
+      - dev
 jobs:
   test-on-ubuntu:
     runs-on: ubuntu-latest

--- a/include/maddy/headlineparser.h
+++ b/include/maddy/headlineparser.h
@@ -57,9 +57,11 @@ public:
    */
   HeadlineParser(
     std::function<void(std::string&)> parseLineCallback,
-    std::function<std::shared_ptr<BlockParser>(const std::string& line)> getBlockParserForLineCallback
+    std::function<std::shared_ptr<BlockParser>(const std::string& line)> getBlockParserForLineCallback,
+    bool isInlineParserAllowed = true
   )
     : BlockParser(parseLineCallback, getBlockParserForLineCallback)
+    , isInlineParserAllowed(isInlineParserAllowed)
   {}
 
   /**
@@ -103,7 +105,7 @@ protected:
   bool
   isLineParserAllowed() const override
   {
-    return false;
+    return this->isInlineParserAllowed;
   }
 
   void
@@ -131,6 +133,9 @@ protected:
       line = std::regex_replace(line, hlRegex[i], hlReplacement[i]);
     }
   }
+
+private:
+  bool isInlineParserAllowed;
 }; // class HeadlineParser
 
 // -----------------------------------------------------------------------------

--- a/include/maddy/parser.h
+++ b/include/maddy/parser.h
@@ -287,10 +287,22 @@ private:
       maddy::HeadlineParser::IsStartingLine(line)
     )
     {
-      parser = std::make_shared<maddy::HeadlineParser>(
-        nullptr,
-        nullptr
-      );
+      if (!this->config || this->config->isHeadlineInlineParsingEnabled)
+      {
+        parser = std::make_shared<maddy::HeadlineParser>(
+          [this](std::string& line){ this->runLineParser(line); },
+          nullptr,
+          true
+        );
+      }
+      else
+      {
+        parser = std::make_shared<maddy::HeadlineParser>(
+          nullptr,
+          nullptr,
+          false
+        );
+      }
     }
     else if (
       (

--- a/include/maddy/parserconfig.h
+++ b/include/maddy/parserconfig.h
@@ -70,11 +70,22 @@ struct ParserConfig
   */
   bool isHTMLWrappedInParagraph;
 
+  /**
+   * en-/disable headline inline-parsing
+   *
+   * default: enabled
+  */
+  bool isHeadlineInlineParsingEnabled;
+
+  /**
+   * enabled parsers bitfield
+  */
   uint32_t enabledParsers;
 
   ParserConfig()
     : isEmphasizedParserEnabled(true)
     , isHTMLWrappedInParagraph(true)
+    , isHeadlineInlineParsingEnabled(true)
     , enabledParsers(maddy::types::DEFAULT)
   {}
 }; // class ParserConfig

--- a/tests/maddy/test_maddy_parser.cpp
+++ b/tests/maddy/test_maddy_parser.cpp
@@ -64,3 +64,34 @@ TEST(MADDY_PARSER, ItShouldParseWithSmallConfig)
 
   ASSERT_EQ(testHtml3, output);
 }
+
+TEST(MADDY_PARSER, ItShouldParseInlineCodeInHeadlines)
+{
+  const std::string headlineTest = R"(
+# Some **test** markdown
+)";
+  const std::string expectedHTML = "<h1>Some <strong>test</strong> markdown</h1>";
+  std::stringstream markdown(headlineTest);
+
+  auto parser = std::make_shared<maddy::Parser>();
+
+  const std::string output = parser->Parse(markdown);
+
+  ASSERT_EQ(expectedHTML, output);
+}
+
+TEST(MADDY_PARSER, ItShouldNotParseInlineCodeInHeadlineIfDisabled)
+{
+  const std::string headlineTest = R"(
+# Some **test** markdown
+)";
+  const std::string expectedHTML = "<h1>Some **test** markdown</h1>";
+  std::stringstream markdown(headlineTest);
+  auto config = std::make_shared<maddy::ParserConfig>();
+  config->isHeadlineInlineParsingEnabled = false;
+  auto parser = std::make_shared<maddy::Parser>(config);
+
+  const std::string output = parser->Parse(markdown);
+
+  ASSERT_EQ(expectedHTML, output);
+}


### PR DESCRIPTION
As in #47  seen, inline parsing in headlines wasn't enabled.