### PR TITLE
make sure all inline block parsers finished

### DIFF
--- a/include/maddy/parser.h
+++ b/include/maddy/parser.h
@@ -178,7 +178,7 @@ public:
     }
 
     // make sure, that all parsers are finished
-    if (currentBlockParser)
+    while (currentBlockParser)
     {
       std::string emptyLine = "";
       currentBlockParser->AddLine(emptyLine);


### PR DESCRIPTION
If the last line in the input mardown has inline blocks, the "if" statement finishes only the most inner one, so the last line is lost in the output. To finish all inline blocks it's needed to feed an empty string for each of them, so "if" needs to be rplaces with "while".

Consider the following mardown input:
```
std::stringstream inputMarkdown(R"(
Some test as the main paragraph

> Some text as a block-quote)");
```