### PR TITLE
Add Cmake install and find_package support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ maddy uses [semver versioning](https://semver.org/).
 
 ## Upcoming
 
-* ...
+* ![**ADDED**](https://img.shields.io/badge/-ADDED-%23099) Added CMake install and find_package() support.
 
 ## version 1.5.0 2025-04-21
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,10 +3,11 @@
 
 cmake_minimum_required(VERSION 3.25)
 
-project(maddy)
+project(maddy VERSION 1.5.0)
 
 # ------------------------------------------------------------------------------
 
+include(GNUInstallDirs)
 set(CMAKE_BINARY_DIR ${CMAKE_CURRENT_SOURCE_DIR}/build)
 set(EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR})
 set(LIBRARY_OUTPUT_PATH ${CMAKE_BINARY_DIR})
@@ -41,7 +42,8 @@ endif()
 
 add_library(maddy INTERFACE)
 target_include_directories(maddy INTERFACE
-  ${MADDY_INCLUDE_DIR}
+  $<BUILD_INTERFACE:${MADDY_INCLUDE_DIR}>
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
 # ------------------------------------------------------------------------------
@@ -64,3 +66,32 @@ if(${MADDY_CREATE_PACKAGE})
     DEPENDS ${MADDY_PACKAGE_FILES})
   add_custom_target(${PROJECT_NAME}_package DEPENDS ${CMAKE_BINARY_DIR}/${PROJECT_NAME}-src.zip)
 endif()
+
+
+include(CMakePackageConfigHelpers)
+
+install(DIRECTORY include/
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+install(TARGETS ${PROJECT_NAME}
+    EXPORT ${PROJECT_NAME}Targets
+    INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+install(EXPORT ${PROJECT_NAME}Targets
+    FILE ${PROJECT_NAME}Targets.cmake
+    NAMESPACE ${PROJECT_NAME}::
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
+)
+write_basic_package_version_file(${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
+    VERSION ${PROJECT_VERSION}
+    COMPATIBILITY SameMinorVersion
+)
+configure_package_config_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/${PROJECT_NAME}Config.cmake.in
+    ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
+    INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
+)
+install(FILES
+        ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
+        ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
+)

--- a/README.md
+++ b/README.md
@@ -30,7 +30,16 @@ The supported syntax can be found in the [definitions docs](docs/definitions.md)
 
 ## How to add maddy to your cmake project
 
-You can use [FetchContent](https://cmake.org/cmake/help/latest/module/FetchContent.html)
+Use `find_package()` which provides `maddy::maddy` target:
+
+```cmake
+find_package(maddy REQUIRED)
+
+add_executable(my_exe)
+target_link_libraries(my_exe PRIVATE maddy::maddy)
+```
+
+Or you can use [FetchContent](https://cmake.org/cmake/help/latest/module/FetchContent.html)
 which was introduced in CMake 3.11.
 
 This way you can add

--- a/cmake/maddyConfig.cmake.in
+++ b/cmake/maddyConfig.cmake.in
@@ -1,0 +1,4 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/maddyTargets.cmake")
+check_required_components(maddy)


### PR DESCRIPTION
### Description of the change

Adds install and find_package support for CMake. Install commands (ie. `make install`) will now install all files needed.

Consumers can now use:

```cmake
find_package(maddy REQUIRED)

add_executable(my_exe)
target_link_libraries(my_exe PRIVATE maddy::maddy)
```
(Readme is updated with that example)

### Checklist for contributor

* [ ] if you want to be mentioned in the [AUTHORS](https://github.com/progsource/maddy/blob/master/AUTHORS) file, you added yourself
* [x] added an entry to [CHANGELOG.md](https://github.com/progsource/maddy/blob/master/CHANGELOG.md) at "Upcoming"
* [ ] if any Markdown definition changed, you updated the [definition docs](https://github.com/progsource/maddy/blob/master/docs/definitions.md)
* [ ] your C++ code change is accommodated with a unit/integration test where it makes sense
* [x] your code meets the code format style (clang-format) of the project (`tools/format.py`)
